### PR TITLE
fix: fixes url and port

### DIFF
--- a/silex_client/network/websocket.py
+++ b/silex_client/network/websocket.py
@@ -45,7 +45,7 @@ class WebsocketConnection:
             context_metadata = {}
         self.context_metadata = context_metadata
         if url is None:
-            url = "http://localhost:8080"
+            url = "http://127.0.0.1:5118"
         self.url = url
 
         # Register the different namespaces

--- a/silex_client/utils/context.py
+++ b/silex_client/utils/context.py
@@ -25,7 +25,7 @@ class Context:
 
     _metadata = {}
 
-    def __init__(self, ws_url: str = "ws://localhost:3000"):
+    def __init__(self, ws_url: str = "ws://127.0.0.1:5118"):
         self._metadata = {}
         self.config: Config = Config()
         self._metadata: dict = {"name": None, "uid": uuid.uuid1()}


### PR DESCRIPTION
When running the WS connection in multi threaded mode in Python 3.9:

```python
# start.py
from silex_client.utils.context import Context

Context.get().ws_connection.url='http://localhost:3000'
Context.get().ws_connection.start_multithreaded()
```

```bash
$ rez env python silex_client -- python start.py
```

I was getting the following error: 

```
[SILEX]    [210923 18:11:32] DEBUG     |    [context.update_dcc] No supported dcc detected                          (121)
Exception in thread Thread-1:
Traceback (most recent call last):
  File "/home/josephhenry/packages/python/3.9.5/platform-linux/arch-x86_64/os-Pop-21.04/python/lib/threading.py", line 954, in _bootstrap_inner
    self.run()
  File "/home/josephhenry/packages/python/3.9.5/platform-linux/arch-x86_64/os-Pop-21.04/python/lib/threading.py", line 892, in run
    self._target(*self._args, **self._kwargs)
  File "/home/josephhenry/Documents/artfx/pipeline/silex/git/silex_client/silex_client/network/websocket.py", line 99, in _start_event_loop
    self.loop.run_until_complete(socketio_connection)
  File "/home/josephhenry/packages/python/3.9.5/platform-linux/arch-x86_64/os-Pop-21.04/python/lib/asyncio/base_events.py", line 642, in run_until_complete
    return future.result()
  File "/home/josephhenry/Documents/artfx/pipeline/silex/git/silex_client/silex_client/network/websocket.py", line 60, in _listen_socketio
    await self.socketio.connect(self.url)
  File "/home/josephhenry/packages/python_socketio/5.4.0/32383fc90933199c950ca6823b6d1e0f634651b6/python/socketio/asyncio_client.py", line 137, in connect
    await self.eio.connect(real_url, headers=real_headers,
  File "/home/josephhenry/packages/python_engineio/4.2.1/32383fc90933199c950ca6823b6d1e0f634651b6/python/engineio/asyncio_client.py", line 110, in connect
    return await getattr(self, '_connect_' + self.transports[0])(
  File "/home/josephhenry/packages/python_engineio/4.2.1/32383fc90933199c950ca6823b6d1e0f634651b6/python/engineio/asyncio_client.py", line 207, in _connect_polling
    r = await self._send_request(
  File "/home/josephhenry/packages/python_engineio/4.2.1/32383fc90933199c950ca6823b6d1e0f634651b6/python/engineio/asyncio_client.py", line 412, in _send_request
    return await http_method(
  File "/home/josephhenry/packages/aiohttp/3.7.4.post0/aa5f91efedaf4e44f5a39182b35f43e3c6551faa/python/aiohttp/client.py", line 520, in _request
    conn = await self._connector.connect(
  File "/home/josephhenry/packages/aiohttp/3.7.4.post0/aa5f91efedaf4e44f5a39182b35f43e3c6551faa/python/aiohttp/connector.py", line 535, in connect
    proto = await self._create_connection(req, traces, timeout)
  File "/home/josephhenry/packages/aiohttp/3.7.4.post0/aa5f91efedaf4e44f5a39182b35f43e3c6551faa/python/aiohttp/connector.py", line 892, in _create_connection
    _, proto = await self._create_direct_connection(req, traces, timeout)
  File "/home/josephhenry/packages/aiohttp/3.7.4.post0/aa5f91efedaf4e44f5a39182b35f43e3c6551faa/python/aiohttp/connector.py", line 999, in _create_direct_connection
    hosts = await asyncio.shield(host_resolved)
  File "/home/josephhenry/packages/aiohttp/3.7.4.post0/aa5f91efedaf4e44f5a39182b35f43e3c6551faa/python/aiohttp/connector.py", line 865, in _resolve_host
    addrs = await self._resolver.resolve(host, port, family=self._family)
  File "/home/josephhenry/packages/aiohttp/3.7.4.post0/aa5f91efedaf4e44f5a39182b35f43e3c6551faa/python/aiohttp/resolver.py", line 31, in resolve
    infos = await self._loop.getaddrinfo(
  File "/home/josephhenry/packages/python/3.9.5/platform-linux/arch-x86_64/os-Pop-21.04/python/lib/asyncio/base_events.py", line 856, in getaddrinfo
    return await self.run_in_executor(
  File "/home/josephhenry/packages/python/3.9.5/platform-linux/arch-x86_64/os-Pop-21.04/python/lib/asyncio/base_events.py", line 809, in run_in_executor
    executor = concurrent.futures.ThreadPoolExecutor(
  File "/home/josephhenry/packages/python/3.9.5/platform-linux/arch-x86_64/os-Pop-21.04/python/lib/concurrent/futures/__init__.py", line 49, in __getattr__
    from .thread import ThreadPoolExecutor as te
  File "/home/josephhenry/packages/python/3.9.5/platform-linux/arch-x86_64/os-Pop-21.04/python/lib/concurrent/futures/thread.py", line 37, in <module>
    threading._register_atexit(_python_exit)
  File "/home/josephhenry/packages/python/3.9.5/platform-linux/arch-x86_64/os-Pop-21.04/python/lib/threading.py", line 1374, in _register_atexit
    raise RuntimeError("can't register atexit after shutdown")
RuntimeError: can't register atexit after shutdown
Unclosed client session
client_session: <aiohttp.client.ClientSession object at 0x7ffa7f6f69a0>
Task was destroyed but it is pending!
task: <Task pending name='Task-2' coro=<WebsocketConnection._emmit_socketio() running at /home/josephhenry/Documents/artfx/pipeline/silex/git/silex_client/silex_client/network/websocket.py:72> wait_for=<Future pending cb=[<TaskWakeupMethWrapper object at 0x7ffa7f654190>()]>>
```

As stated in [this](https://stackoverflow.com/questions/65467329/server-in-a-thread-python3-9-0aiohttp-runtimeerror-cant-register-atexit-a) thread, a fix is to use `127.0.0.1` instead of `localhost` (don't ask me why???)

I also fixed the port number as discussed :+1: 